### PR TITLE
Better support for eldoc

### DIFF
--- a/outshine.el
+++ b/outshine.el
@@ -2357,6 +2357,10 @@ overwritten, and the table is not marked as requiring realignment."
 ;; trigger company idle completion like namesake command
 (put 'outshine-self-insert-command 'company-begin t)
 
+;; trigger eldoc (elisp help in echo area), like `self-insert-command'
+(with-eval-after-load 'eldoc
+  (eldoc-add-command 'outshine-self-insert-command))
+
 ;;;;; Other Commands
 
 (defun outshine-eval-lisp-subtree ()

--- a/outshine.el
+++ b/outshine.el
@@ -2358,8 +2358,8 @@ overwritten, and the table is not marked as requiring realignment."
 (put 'outshine-self-insert-command 'company-begin t)
 
 ;; trigger eldoc (elisp help in echo area), like `self-insert-command'
-(with-eval-after-load 'eldoc
-  (eldoc-add-command 'outshine-self-insert-command))
+(eval-after-load 'eldoc
+  '(eldoc-add-command 'outshine-self-insert-command))
 
 ;;;;; Other Commands
 

--- a/outshine.el
+++ b/outshine.el
@@ -2358,8 +2358,8 @@ overwritten, and the table is not marked as requiring realignment."
 (put 'outshine-self-insert-command 'company-begin t)
 
 ;; trigger eldoc (elisp help in echo area), like `self-insert-command'
-(eval-after-load 'eldoc
-  '(eldoc-add-command 'outshine-self-insert-command))
+(with-eval-after-load 'eldoc
+  (eldoc-add-command 'outshine-self-insert-command))
 
 ;;;;; Other Commands
 


### PR DESCRIPTION
Hi!

When I enabled outshine, I noticed that eldoc (the Emacs Lisp help messages in the echo area) didn't work properly. This pull request adds support for eldoc, so that it works the way it does without outshine.

Thanks!

\- John