### PR TITLE
Delete buggy outline-hide-sublevels (Fix #15)

### DIFF
--- a/outshine.el
+++ b/outshine.el
@@ -1888,24 +1888,6 @@ If yes, return this character."
 ;;;;; Additional outline commands
 ;;;;;; Commands from `out-xtra'
 
-(defun outline-hide-sublevels (keep-levels)
-  "Hide everything except the first KEEP-LEVEL headers."
-  (interactive "p")
-  (if (< keep-levels 1)
-      (error "Must keep at least one level of headers"))
-  (setq keep-levels (1- keep-levels))
-  (save-excursion
-    (goto-char (point-min))
-    ;; Skip the prelude, if any.
-    (unless (outline-on-heading-p t) (outline-next-heading))
-    (hide-subtree)
-    (show-children keep-levels)
-    (condition-case err
-        (while (outline-get-next-sibling)
-          (hide-subtree)
-          (show-children keep-levels))
-      (error nil))))
-
 (defun outline-hide-other ()
   "Hide everything except for the current body and the parent headings."
   (interactive)


### PR DESCRIPTION
This PR removes the reimplementation of `outline-hide-sublevels`, which is the root cause of #15.  The fix is strictly limited to #15, but there's more to do: `outshine.el` overrides *a lot* of `outline.el`, probably for backwards compatibility reason, and these overrides should all be removed, outshine should define names only in the `outshine-` namespace and let the `outline-` namespace alone.