### PR TITLE
Update outshine-version variable

### DIFF
--- a/outshine.el
+++ b/outshine.el
@@ -273,7 +273,7 @@
 ;;; Variables
 ;;;; Consts
 
-(defconst outshine-version "2.0"
+(defconst outshine-version "3.0"
   "outshine version number.")
 
 (defconst outshine-max-level 8
@@ -1650,7 +1650,7 @@ This function will be hooked to `outline-minor-mode'."
              (not outline-minor-mode))
     (outshine-mode 0)))
 
- 
+�
 ;;;;; Additional outline functions
 ;;;;;; Functions from `outline-magic'
 


### PR DESCRIPTION
I was wondering why I couldn't update to 3.0, turned out this was the problem