### PR TITLE
Add preceding space to outshine-mode lighter string

### DIFF
--- a/outshine.el
+++ b/outshine.el
@@ -951,7 +951,7 @@ significant."
   "Outshine brings the look&feel of Org-mode to the (GNU Emacs)
 world outside of the Org major-mode."
   :init-value nil
-  :lighter "Outshine"
+  :lighter " Outshine"
   (if outshine-mode
       (outshine--minor-mode-activate)
     (outshine--minor-mode-deactivate)))


### PR DESCRIPTION
It is conventional to have a preceding space before lighter strings so that all minor mode lighters do not squish together. There are many such examples in Emacs cores. To list to few, look at the definitions of `hs-minor-mode` and `eldoc-mode`.