### PR TITLE
Fixes to outshine-define-key-with-fallback

### DIFF
--- a/README.org
+++ b/README.org
@@ -69,7 +69,12 @@ The very useful Org speed commands are available in ~outshine~.  To activate the
 
 ** 3.1-pre
 
-Nothing new yet.
+*Added*
++ Add ~outshine-define-key~ macro for defining conditional key bindings (e.g. on headlines). Improves on previous ~outshine-define-key-with-fallback~ macro by interning a named function and matching the function signature of ~define-key~.
++ Bind @@html:<kbd>@@ <backtab> @@html:</kbd>@@ to ~outshine-cycle-buffer~ on headlines
+
+*Deprecated*
++ Declare ~outshine-define-key-with-fallback~ as obsolete, use ~outshine-define-key~ instead
 
 ** 3.0 and earlier
 

--- a/outshine.el
+++ b/outshine.el
@@ -846,7 +846,7 @@ This function will be hooked to `outline-minor-mode'."
 
 ;; copied and adapted from Alexander Vorobiev
 ;; http://www.mail-archive.com/emacs-orgmode@gnu.org/msg70648.html
-(defmacro outshine-define-key-with-fallback
+(defmacro outshine-define-key
     (keymap key def condition &optional mode)
   "Define key with fallback.
 
@@ -2351,44 +2351,44 @@ marking subtree (and subsequently run the tex command)."
 
 ;;;;;; Visibility Cycling
 
-(outshine-define-key-with-fallback outshine-mode-map
+(outshine-define-key outshine-mode-map
   (kbd "TAB") 'outshine-cycle
   (or (outline-on-heading-p)
       (and (bobp) outshine-org-style-global-cycling-at-bob-p)))
 
-(outshine-define-key-with-fallback outshine-mode-map
+(outshine-define-key outshine-mode-map
   (kbd "<backtab>") 'outshine-cycle-buffer
   (or (outline-on-heading-p) (bobp)))
 
 ;; Works on the console too.
 (define-key outshine-mode-map (kbd "M-TAB") 'outshine-cycle-buffer)
 
-(outshine-define-key-with-fallback outshine-mode-map
+(outshine-define-key outshine-mode-map
   (kbd "M-<left>") 'outshine-hide-more
   (outline-on-heading-p))
 
-(outshine-define-key-with-fallback outshine-mode-map
+(outshine-define-key outshine-mode-map
   (kbd "M-<right>") 'outshine-show-more
   (outline-on-heading-p))
 
 ;;;;;; Headline Insertion
 
-(outshine-define-key-with-fallback outshine-mode-map
+(outshine-define-key outshine-mode-map
   (kbd "M-RET") 'outshine-insert-heading
   (outline-on-heading-p))
 
 ;;;;;; Structure Editing
 
-(outshine-define-key-with-fallback outshine-mode-map
+(outshine-define-key outshine-mode-map
   (kbd "M-S-<left>") 'outline-promote
   (outline-on-heading-p))
-(outshine-define-key-with-fallback outshine-mode-map
+(outshine-define-key outshine-mode-map
   (kbd "M-S-<right>") 'outline-demote
   (outline-on-heading-p))
-(outshine-define-key-with-fallback outshine-mode-map
+(outshine-define-key outshine-mode-map
   (kbd "M-S-<up>") 'outline-move-subtree-up
   (outline-on-heading-p))
-(outshine-define-key-with-fallback outshine-mode-map
+(outshine-define-key outshine-mode-map
   (kbd "M-S-<down>") 'outline-move-subtree-down
   (outline-on-heading-p))
 

--- a/outshine.el
+++ b/outshine.el
@@ -853,12 +853,15 @@ Binds KEY to definition DEF in keymap KEYMAP, the binding is
 active when the CONDITION is true. Otherwise turns MODE off and
 re-enables previous definition for KEY. If MODE is nil, tries to
 recover it by stripping off \"-map\" from KEYMAP name."
+  (when (eq (car-safe def) 'quote)
+    (setq def (cadr def)))
   `(define-key
      ,keymap
      ,key
-     (lambda (&optional arg)
-       (interactive "P")
-       (if ,condition ,def
+     (lambda ()
+       (interactive)
+       (if ,condition
+           (call-interactively ',def)
          (let* ((,(if mode mode
                     (let* ((keymap-str (symbol-name keymap))
                            (mode-name-end
@@ -881,7 +884,7 @@ recover it by stripping off \"-map\" from KEYMAP name."
            (condition-case nil
                (call-interactively original-func)
              (error nil)))))))
-(put 'outshine-define-key-with-fallback 'lisp-indent-function 2)
+(put 'outshine-define-key-with-fallback 'lisp-indent-function 1)
 
 ;;;;; Normalize regexps
 
@@ -2340,52 +2343,49 @@ marking subtree (and subsequently run the tex command)."
 
 ;;;;;; Visibility Cycling
 
-(outshine-define-key-with-fallback
-    outshine-mode-map (kbd "TAB")
-  (outshine-cycle arg)
-  (or (and (bobp) (not (outline-on-heading-p))
-           outshine-org-style-global-cycling-at-bob-p)
-      (outline-on-heading-p)))
+(outshine-define-key-with-fallback outshine-mode-map
+  (kbd "TAB") 'outshine-cycle
+  (or (outline-on-heading-p)
+      (and (bobp) outshine-org-style-global-cycling-at-bob-p)))
 
 ;; Works on the console too.
 (define-key outshine-mode-map (kbd "M-TAB") 'outshine-cycle-buffer)
 
-(outshine-define-key-with-fallback
-    outshine-mode-map (kbd "M-<left>")
-  (outshine-hide-more) (outline-on-heading-p))
+(outshine-define-key-with-fallback outshine-mode-map
+  (kbd "M-<left>") 'outshine-hide-more
+  (outline-on-heading-p))
 
-(outshine-define-key-with-fallback
-    outshine-mode-map (kbd "M-<right>")
-  (outshine-show-more) (outline-on-heading-p))
+(outshine-define-key-with-fallback outshine-mode-map
+  (kbd "M-<right>") 'outshine-show-more
+  (outline-on-heading-p))
 
 ;;;;;; Headline Insertion
 
-(outshine-define-key-with-fallback
-    outshine-mode-map (kbd "M-RET")
-  (outshine-insert-heading) (outline-on-heading-p))
+(outshine-define-key-with-fallback outshine-mode-map
+  (kbd "M-RET") 'outshine-insert-heading
+  (outline-on-heading-p))
 
 ;;;;;; Structure Editing
 
-(outshine-define-key-with-fallback
-    outshine-mode-map (kbd "M-S-<left>")
-  (outline-promote) (outline-on-heading-p))
-
-(outshine-define-key-with-fallback
-    outshine-mode-map (kbd "M-S-<right>")
-  (outline-demote) (outline-on-heading-p))
-
-(outshine-define-key-with-fallback
-    outshine-mode-map (kbd "M-S-<up>")
-  (outline-move-subtree-up) (outline-on-heading-p))
-
-(outshine-define-key-with-fallback
-    outshine-mode-map (kbd "M-S-<down>")
-  (outline-move-subtree-down) (outline-on-heading-p))
+(outshine-define-key-with-fallback outshine-mode-map
+  (kbd "M-S-<left>") 'outline-promote
+  (outline-on-heading-p))
+(outshine-define-key-with-fallback outshine-mode-map
+  (kbd "M-S-<right>") 'outline-demote
+  (outline-on-heading-p))
+(outshine-define-key-with-fallback outshine-mode-map
+  (kbd "M-S-<up>") 'outline-move-subtree-up
+  (outline-on-heading-p))
+(outshine-define-key-with-fallback outshine-mode-map
+  (kbd "M-S-<down>") 'outline-move-subtree-down
+  (outline-on-heading-p))
 
 ;;;;;; Motion
 
-(define-key outshine-mode-map [M-up] 'outline-previous-visible-heading)
-(define-key outshine-mode-map [M-down] 'outline-next-visible-heading)
+(define-key outshine-mode-map
+  [M-up] 'outline-previous-visible-heading)
+(define-key outshine-mode-map
+  [M-down] 'outline-next-visible-heading)
 
 ;;;;; Other Keybindings
 ;; refer to Key Bindings section in outshine-org-cmds.el

--- a/outshine.el
+++ b/outshine.el
@@ -2356,6 +2356,10 @@ marking subtree (and subsequently run the tex command)."
   (or (outline-on-heading-p)
       (and (bobp) outshine-org-style-global-cycling-at-bob-p)))
 
+(outshine-define-key-with-fallback outshine-mode-map
+  (kbd "<backtab>") 'outshine-cycle-buffer
+  (or (outline-on-heading-p) (bobp)))
+
 ;; Works on the console too.
 (define-key outshine-mode-map (kbd "M-TAB") 'outshine-cycle-buffer)
 


### PR DESCRIPTION
Closes #48 

This PR is a superset of the changes in #43, except the corresponding first commit fa1f18e does a bit more, also making some reformatting changes and accepting unquoted symbols for the DEF argument.

The second commit Interns a named function with appropriate docstring instead of a lambda,
so that calling describe-key (eg. `C-h k TAB`) produces the following:

```
TAB (translated from <tab>) runs the command outshine-TAB-with-fallback (found
in outshine-mode-map) [...]

Run the interactive command ‘outshine-cycle’ if the following condition is satisfied:

    (or (outline-on-heading-p) (and (bobp) outshine-org-style-global-cycling-at-bob-p))

Otherwise, fallback to the original binding of (kbd "TAB") in the current mode.
```

The last commit is not strictly related and can be dropped from this PR if needed, it binds `<backtab>` to `outshine-cycle-buffer` on headings, following the standard Org mode binding.