### PR TITLE
Implement 2-state cycling for headings without child subheadings

### DIFF
--- a/outshine.el
+++ b/outshine.el
@@ -1715,13 +1715,14 @@ condition among the following:
    - SHOW ALL: Show everything.
 
  2. When point is at the beginning of a headline, rotate the
-    subtree starting at this line through 3 different states:
+    subtree starting at this line through 2 or 3 different states:
 
    - FOLDED:   Only the main headline is shown.
    - CHILDREN: The main headline and its direct children are shown.
                From this state, you can move to one of the children
                and zoom in further.
-
+               * If the heading has no direct children, this state
+               is skipped entirely.
    - SUBTREE:  Show the entire subtree, including body text.
 
  3. Otherwise, execute `indent-relative', like TAB normally does.
@@ -1745,12 +1746,16 @@ variables: `outshine-cycle-emulate-tab` and
    ;; At a heading: rotate between three different views
    ((save-excursion (beginning-of-line 1) (looking-at outline-regexp))
     (outline-back-to-heading)
-    (let ((goal-column 0) eoh eol eos)
+    (let ((goal-column 0) eoh eol eos has-children)
       ;; First, some boundaries
       (save-excursion
         (save-excursion (outshine-next-line) (setq eol (point)))
         (outline-end-of-heading)             (setq eoh (point))
         (outline-end-of-subtree)             (setq eos (point)))
+      (setq has-children
+            ;; nil if no other heading between heading and end of subtree
+            (save-excursion (end-of-line)
+                            (re-search-forward outline-regexp eos 'noerror)))
       ;; Find out what to do next and set `this-command'
       (cond
        ((= eos eoh)
@@ -1758,11 +1763,14 @@ variables: `outshine-cycle-emulate-tab` and
         (outshine--cycle-message "EMPTY ENTRY"))
        ((>= eol eos)
         ;; Entire subtree is hidden in one line: open it
-        (outline-show-entry)
-        (outline-show-children)
-        (outshine--cycle-message "CHILDREN")
-        (setq
-         this-command 'outshine-cycle-children))
+        (if has-children
+            (progn
+              (outline-show-entry)
+              (outline-show-children)
+              (outshine--cycle-message "CHILDREN")
+              (setq this-command 'outshine-cycle-children))
+          (outline-show-subtree)
+          (outshine--cycle-message "SUBTREE (NO CHILDREN)")))
        ((eq last-command 'outshine-cycle-children)
         ;; We just showed the children, now show everything.
         (outline-show-subtree)

--- a/outshine.el
+++ b/outshine.el
@@ -1746,16 +1746,14 @@ variables: `outshine-cycle-emulate-tab` and
    ;; At a heading: rotate between three different views
    ((save-excursion (beginning-of-line 1) (looking-at outline-regexp))
     (outline-back-to-heading)
-    (let ((goal-column 0) eoh eol eos has-children)
-      ;; First, some boundaries
-      (save-excursion
-        (save-excursion (outshine-next-line) (setq eol (point)))
-        (outline-end-of-heading)             (setq eoh (point))
-        (outline-end-of-subtree)             (setq eos (point)))
-      (setq has-children
-            ;; nil if no other heading between heading and end of subtree
+    (let* ((goal-column 0)
+           ;; First, some boundaries
+           (eol (save-excursion (outshine-next-line) (point)))
+           (eoh (save-excursion (outline-end-of-heading) (point)))
+           (eos (save-excursion (outline-end-of-subtree) (point)))
+           (has-children ;; nil if no other heading between heading and end of subtree
             (save-excursion (end-of-line)
-                            (re-search-forward outline-regexp eos 'noerror)))
+                            (re-search-forward outline-regexp eos 'noerror))))
       ;; Find out what to do next and set `this-command'
       (cond
        ((= eos eoh)


### PR DESCRIPTION
This allows for `outshine-cycle` to cycle between fold / unfold for simple headings without children subheadings, without going through the no-op `CHILDREN` state.

The logic for this is mostly taken from org-cycle.