### PR TITLE
Fix Easy Menu to move subtrees correctly

### DIFF
--- a/outshine.el
+++ b/outshine.el
@@ -2313,9 +2313,9 @@ marking subtree (and subsequently run the tex command)."
      :active (outline-on-heading-p) :keys "M-S-<left>"]
     ["Demote Heading" outline-demote
      :active (outline-on-heading-p) :keys "M-S-<right>"]
-    ["Move Heading Up" outline-move-heading-up
+    ["Move Heading Up" outline-move-subtree-up
      :active (outline-on-heading-p) :keys "M-S-<up>"]
-    ["Move Heading Down" outline-move-heading-down
+    ["Move Heading Down" outline-move-subtree-down
      :active (outline-on-heading-p) :keys "M-S-<down>"]
     "--"
     ["Previous Visible Heading" outline-previous-visible-heading


### PR DESCRIPTION
The functions `outline-move-heading-{up, down}` in Easy menu seems to be void.  Therefore I replace them with `outline-move-subtree-{up, down}`.  I do not know whether this fix is a good way or not.  However, the fixed `outlshine.el` works well at least on my environment (GNU Emacs 26.2 on macOS mojave).

For more detail, please refer to [my issue comment (3)](https://github.com/alphapapa/outshine/issues/63#issuecomment-485234335).