### PR TITLE
(goto-char beg) through error from comment-region-default calledby co…

### DIFF
--- a/outshine.el
+++ b/outshine.el
@@ -766,9 +766,10 @@ Don't use this function, the public interface is
            ;; stay after inserted text
            (copy-marker (outshine-mimic-org-log-note-marker) t)))
       ad-do-it
-      (unless (derived-mode-p 'org-mode 'org-agenda-mode)
-        (outshine-comment-region outshine-log-note-beg-marker
-                                 outshine-log-note-end-marker))
+            (unless (derived-mode-p 'org-mode 'org-agenda-mode)
+                    (with-current-buffer (marker-buffer org-log-note-marker)
+                            (outshine-comment-region outshine-log-note-beg-marker
+                                    outshine-log-note-end-marker)))
       (move-marker outshine-log-note-beg-marker nil)
       (move-marker outshine-log-note-end-marker nil)))
 


### PR DESCRIPTION
…mment-region calledby outshine-comment-region

(goto-char beg) through (error "Marker points into wrong buffer" #<marker at POS in FILE>)
 from comment-region-default calledby comment-region calledby outshine-comment-region

When org-store-log-note is called through org-clock-out