### PR TITLE
(goto-char beg) through error from comment-region-default calledby

### DIFF
--- a/outshine.el
+++ b/outshine.el
@@ -766,9 +766,10 @@ Don't use this function, the public interface is
            ;; stay after inserted text
            (copy-marker (outshine-mimic-org-log-note-marker) t)))
       ad-do-it
-      (unless (derived-mode-p 'org-mode 'org-agenda-mode)
-        (outshine-comment-region outshine-log-note-beg-marker
-                                 outshine-log-note-end-marker))
+            (unless (derived-mode-p 'org-mode 'org-agenda-mode)
+                    (with-current-buffer (marker-buffer org-log-note-marker)
+                            (outshine-comment-region outshine-log-note-beg-marker
+                                    outshine-log-note-end-marker)))
       (move-marker outshine-log-note-beg-marker nil)
       (move-marker outshine-log-note-end-marker nil)))
 


### PR DESCRIPTION
comment-region calledby outshine-comment-region
In adviced org-store-log-note, execution end up into error by
(goto-char POSITION) function as current buffer and marker-buffer are not same.

Debugger entered--Lisp error: (error "Marker points into wrong buffer" #<marker at 28600 in report.org>)
  comment-region-default(#<marker at 28600 in report.org> #<marker (moves after insertion) at 28600 in report.org> nil)
  comment-region(#<marker at 28600 in report.org> #<marker (moves after insertion) at 28600 in report.org> nil)
  outshine-comment-region(#<marker at 28600 in report.org> #<marker (moves after insertion) at 28600 in report.org>)
  ad-Advice-org-store-log-note
  apply(ad-Advice-org-store-log-note
  org-store-log-note()
  org-ctrl-c-ctrl-c(nil)
  funcall-interactively(org-ctrl-c-ctrl-c nil)
  call-interactively(org-ctrl-c-ctrl-c nil nil)
  command-execute(org-ctrl-c-ctrl-c)

(goto-char beg) through (error "Marker points into wrong buffer" #<marker at POS in FILE>)
 from comment-region-default calledby comment-region calledby outshine-comment-region

When org-store-log-note is called through org-clock-out