### PR TITLE
Quick fix of #75

### DIFF
--- a/outshine.el
+++ b/outshine.el
@@ -2369,8 +2369,9 @@ marking subtree (and subsequently run the tex command)."
 
 ;;;;; Principal Keybindings
 
-(define-key outshine-mode-map
-  [remap self-insert-command] 'outshine-self-insert-command)
+(when outshine-use-speed-commands
+  (define-key outshine-mode-map
+    [remap self-insert-command] 'outshine-self-insert-command))
 
 ;; Adapted from `org-mode' and `outline-mode-easy-bindings'.
 

--- a/outshine.el
+++ b/outshine.el
@@ -1295,23 +1295,6 @@ Use `outshine-speed-commands-user' for further customization."
     (cdr (assoc keys (append outshine-speed-commands-user
                              outshine-speed-commands-default)))))
 
-(defun outshine-defkey (keymap key def)
-  "Define a KEY in a KEYMAP with definition DEF."
-  (define-key keymap key def))
-
-(defun outshine-remap (map &rest commands)
-  "In MAP, remap the functions given in COMMANDS.
-COMMANDS is a list of alternating OLDDEF NEWDEF command names."
-  (let (new old)
-    (while commands
-      (setq old (pop commands) new (pop commands))
-      (if (fboundp 'command-remapping)
-          (outshine-defkey map (vector 'remap old) new)
-        (substitute-key-definition old new map global-map)))))
-
-(outshine-remap outshine-mode-map
-                'self-insert-command 'outshine-self-insert-command)
-
 ;;;;; Functions for hiding comment-subtrees
 
 (defun outshine-hide-comment-subtrees-in-region (beg end)
@@ -2387,6 +2370,9 @@ marking subtree (and subsequently run the tex command)."
 ;;;; Keybindings
 
 ;;;;; Principal Keybindings
+
+(define-key outshine-mode-map
+  [remap self-insert-command] 'outshine-self-insert-command)
 
 ;; Adapted from `org-mode' and `outline-mode-easy-bindings'.
 

--- a/outshine.el
+++ b/outshine.el
@@ -1931,9 +1931,7 @@ If not, return to the original position and throw an error."
 
 
 (defun outshine-self-insert-command (N)
-  "Like `self-insert-command', use overwrite-mode for whitespace in tables.
-If the cursor is in a table looking at whitespace, the whitespace is
-overwritten, and the table is not marked as requiring realignment."
+  "Like `self-insert-command' but performs speed commands at the beginning of headlines."
   (interactive "p")
   ;; (outshine-check-before-invisible-edit 'insert)
   (cond


### PR DESCRIPTION
This PR drops an obsolete workaround for remapping keys and fixes #75 by wrapping the offending code in a `(when outshine-use-speed-commands )` block. 

The consequence of this is that `outshine-use-speed-commands` (`nil` by default) has to be enabled before the package is loaded, and changing it afterwards does not have any effect.