### PR TITLE
Add support for changing the ellipsis

### DIFF
--- a/README.org
+++ b/README.org
@@ -74,6 +74,7 @@ If you experience issues with Emacs not recognizing these bindings when running 
 
 +  ~imenu~ is supported with the command ~outshine-imenu~.
 +  Show the number of hidden lines in folded headlines with the command ~outshine-show-hidden-lines-cookies~.
++  Change the default ellipsis text by customizing ~outshine-ellipsis~ and restarting the mode.
 +  ~latex-mode~ commands:
      -  ~outshine-latex-insert-header~
      -  ~outshine-latex-insert-headers-in-buffer~

--- a/outshine.el
+++ b/outshine.el
@@ -727,6 +727,11 @@ significant."
   :group 'outshine
   :type 'boolean)
 
+(defcustom outshine-ellipsis nil
+  "Non-nil nor empty changes what is appended at the end of all closed headings."
+  :group 'outshine
+  :type '(choice (const :tag "Default" nil)
+                 (string :tag "String" :value " …")))
 ;;;; Minor mode
 
 ;;;###autoload
@@ -802,7 +807,8 @@ Don't use this function, the public interface is
             (`nil nil)
             ((pred functionp) (funcall outshine-fontify))
             (_ (user-error "Invalid value for variable `outshine-fontify'")))
-      (outshine-fontify-headlines out-regexp))))
+      (outshine-fontify-headlines out-regexp)))
+  (outshine-update-ellipsis))
 
 (defun outshine--minor-mode-deactivate ()
   "Deactivate Outshine.
@@ -1623,6 +1629,25 @@ If yes, return this character."
 ;; `outshine-agenda-old-org-agenda-files'."
 ;;   (setq org-agenda-files outshine-agenda-old-org-agenda-files)
 ;;   (setq outshine-agenda-old-org-agenda-files nil))
+
+;;;;; Update ellipsis
+(defun outshine-update-ellipsis ()
+  "Update `buffer-display-table' with the new value from `outshine-ellipsis'.
+
+If `outshine-ellipsis' is not nil nor empty, update the
+`selective-display' value of the current display-table with the
+value from `outshine-ellipsis'. The resulting display-table is
+always assigned to `buffer-display-table'."
+  (when (and (stringp outshine-ellipsis) (not (equal "" outshine-ellipsis)))
+    (let* ((old-dt (or
+                    (window-display-table)
+                    buffer-display-table
+                    standard-display-table))
+           (display-table (or old-dt (make-display-table))))
+
+      (set-display-table-slot display-table 'selective-display
+                              (string-to-vector outshine-ellipsis))
+      (setq-local buffer-display-table display-table))))
 
 ;;;; Commands
 ;;;;; Additional outline commands


### PR DESCRIPTION
## What
This PR adds support for changing the ellipsis text at the end of closed headings.

## Why
This is not intuitive to do, so having a variable makes it cleaner and easier.

## How
Changing the `'selective-display` value in whatever display-map is active, and making that map local to the buffer.

## Tested
- Ellipsis appears on load on doom emacs, with nil and custom value, on elisp file.
- Ellipsis appears on mode activation on custom emacs config, with nil and custom value, on elisp file.

## Possible problems
- Not tested with the window map being the one active, but it should add the value.
- May modify the standard map if its the one in use.
- Maybe it would be better to copy the map contents instead, but no problems with it yet.