### PR TITLE
(goto-char beg) throw error, when called from function (comment-regio…

### DIFF
--- a/outshine.el
+++ b/outshine.el
@@ -767,8 +767,9 @@ Don't use this function, the public interface is
            (copy-marker (outshine-mimic-org-log-note-marker) t)))
       ad-do-it
       (unless (derived-mode-p 'org-mode 'org-agenda-mode)
-        (outshine-comment-region outshine-log-note-beg-marker
-                                 outshine-log-note-end-marker))
+        (with-current-buffer (marker-buffer org-log-note-marker)
+          (outshine-comment-region outshine-log-note-beg-marker
+                                   outshine-log-note-end-marker)))
       (move-marker outshine-log-note-beg-marker nil)
       (move-marker outshine-log-note-end-marker nil)))
 


### PR DESCRIPTION
…n-default)

Description:
  (goto-char beg) throw error "Marker points into wrong buffer", when current-buffer and marker-buffer are not same

  (goto-char beg) called by comment-region
  which in turn called by outshine-comment-region
  whcih in turn called from adviced org-store-log-note

Reason:
  Issue happens when current-buffer and marker-buffer are not same

  It usually happens when (org-store-log-note) used in uninteractively
  For example:
      Using org-store-log-note in a idle timer to log predefined note in a org file.

      Here org-store-log-note is called through org-clock-out which is called
      from a idle timer function.

Backtrace:
  Debugger entered--Lisp error: (error "Marker points into wrong buffer" #<marker at 28600 in report.org>)
    comment-region-default(#<marker at 28600 in report.org> #<marker (moves after insertion) at 28600 in report.org> nil)
    comment-region(#<marker at 28600 in report.org> #<marker (moves after insertion) at 28600 in report.org> nil)
    outshine-comment-region(#<marker at 28600 in report.org> #<marker (moves after insertion) at 28600 in report.org>)
    ad-Advice-org-store-log-note
    apply(ad-Advice-org-store-log-note
    org-store-log-note()
    org-ctrl-c-ctrl-c(nil)
    funcall-interactively(org-ctrl-c-ctrl-c nil)
    call-interactively(org-ctrl-c-ctrl-c nil nil)
    command-execute(org-ctrl-c-ctrl-c)

Error:
  (goto-char beg) through (error "Marker points into wrong buffer" #<marker at POS in FILE>)
   from comment-region-default calledby comment-region called by
   outshine-comment-region

Solution:
  This error can be fix by wrapping (outshine-comment-region ...) function call
  in (with-current-buffer (marker-buffer org-log-note-marker) ...)