### PR TITLE
more fully override imenu configuration when using outshine's imenu

### DIFF
--- a/outshine.el
+++ b/outshine.el
@@ -2143,6 +2143,7 @@ i.e. the text following the regexp match until the next space character."
               outshine-imenu-generic-expression)
              (imenu-prev-index-position-function nil)
              (imenu-extract-index-name-function nil)
+             (imenu-create-index-function 'imenu-default-create-index-function)
              (imenu-auto-rescan t)
              (imenu-auto-rescan-maxout 360000))
         ;; prefer idomenu
@@ -2173,6 +2174,7 @@ i.e. the text following the regexp match until the next space character."
           outshine-imenu-default-generic-expression)
          (imenu-prev-index-position-function nil)
          (imenu-extract-index-name-function nil)
+         (imenu-create-index-function 'imenu-default-create-index-function)
          (imenu-auto-rescan t)
          (imenu-auto-rescan-maxout 360000))
     ;; prefer idomenu


### PR DESCRIPTION
When using outshine's imenu functionality (from either `outshine-imenu` or
`outshine-imenu-with-navi-regexp`), the variables that configure imenu behavior
are locally overwritten in a `let*` form (so that `imenu` will pick up on `outshine` headings rather than whatever tags would normally be used). However, I think it misses one key variable: it's important to also overwrite `imenu-create-index function`, since if that is changed it essentially nerfs any of the other configuration (see the end part of [the documentation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Imenu.html).

I noticed this bug when editing `R` files in `spacemacs`: my `lsp`
configuration involves changing the value of `imenu-create-index-function`,
which makes changes to the other variables inconsequential, and then outshine's
attempt to change the way imenu works by binding `imenu-generic-expression` has
no effect.

I don't currently use `navi` mode, but I made an analogous fix in `outshine-imenu-with-navi-regexp` which I assume would suffer from the same issue.

I'm happy to also open an issue if it's preferred to have discussion over there, but figured I'd start with the PR since I already had a fix.