### PR TITLE
outshine-speed-commands-default: update to align with org equivalent

### DIFF
--- a/outshine.el
+++ b/outshine.el
@@ -118,8 +118,7 @@ Please report a bug if this needs to be changed.")
     (" " . (outshine-use-outorg
             'org-display-outline-path
             'WHOLE-BUFFER-P))
-    ;; [X]
-    ("r" . outshine-narrow-to-subtree)
+    ("s" . outshine-narrow-to-subtree)
     ;; [X]
     ("w" . widen)
     ;; ;; [ ]
@@ -129,6 +128,11 @@ Please report a bug if this needs to be changed.")
     ("U" . outline-move-subtree-up)
     ;; [X] FIXME error with oldschool elisp headers
     ("D" . outline-move-subtree-down)
+    ;; [X]
+    ("l" . outline-promote)
+    ("r" . outline-demote)
+    ("L" . outline-promote)
+    ("R" . outline-demote)
     ;; [X]
     ("+" . outline-demote)
     ;; [X]
@@ -141,7 +145,7 @@ Please report a bug if this needs to be changed.")
     ;; ("a" . (outshine-use-outorg
     ;;      'org-archive-subtree-default-with-confirmation))
     ;; [X]
-    ("m" . outline-mark-subtree)
+    ("@" . outline-mark-subtree)
     ;; [X]
     ("#" . outshine-toggle-comment)
     ("Clock Commands")


### PR DESCRIPTION
Fix #91. This is a draft PR because there were two problems raised in that issue and so far it only solves one of them -- consistency between the default speed command lists in org and outshine.

The other is that -- unlike org -- outshine inserts new headings _above_ old ones when `outshine-insert-heading` is called with a speed command.

I found that this is because outshine only adds a newline for the new heading after the current one[ if point is _not_ at BOL](https://github.com/alphapapa/outshine/blob/master/outshine.el#L2074). If it is, it inserts the heading there with a trailing newline, pushing the old heading onto the next line. Of course, speed commands (like <kbd>i</kbd>) are invoked from BOL, so this always happens.

It's a very simple fix, just remove the `unless` statement and merge the newline creation into the main body of the function. But before I do that, I wanted to check why there is different behaviour for BOL at all? It seems such a strange exception that I thought it might be a protection for something specific that needs keeping. Basically, is there a good reason _not_ to make the simple fix?