### PR TITLE
Fixing commenting for org-clock-out

### DIFF
--- a/outshine.el
+++ b/outshine.el
@@ -766,9 +766,10 @@ Don't use this function, the public interface is
            ;; stay after inserted text
            (copy-marker (outshine-mimic-org-log-note-marker) t)))
       ad-do-it
-      (unless (derived-mode-p 'org-mode 'org-agenda-mode)
-        (outshine-comment-region outshine-log-note-beg-marker
-                                 outshine-log-note-end-marker))
+      (with-current-buffer (marker-buffer org-log-note-marker)
+        (unless (derived-mode-p 'org-mode 'org-agenda-mode)
+          (outshine-comment-region outshine-log-note-beg-marker
+                                   outshine-log-note-end-marker)))
       (move-marker outshine-log-note-beg-marker nil)
       (move-marker outshine-log-note-end-marker nil)))
 


### PR DESCRIPTION
Added 

(with-current-buffer (marker-buffer org-log-note-marker)
   (unless (derived-mode-p 'org-mode 'org-agenda-mode)
          (outshine-comment-region outshine-log-note-beg-marker
                                   outshine-log-note-end-marker)))


As when org-log-note-clock-out is set
org-clock-out is called, that time org file which has clock may not be current buffer,
and @Fun(outshine-comment-region) is called in any current-buffer than correct org file with clock
In addition it is wrongly picking @Var(comment-start) from wrong current buffer many time it is not defined